### PR TITLE
DX-000 Fix for how maps do not need context

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -379,16 +379,16 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                     context.resolve(new AnnotatedType().type(valueType).jsonViewAnnotation(annotatedType.getJsonViewAnnotation()));
                     return null;
                 }
-                Schema addPropertiesSchema = context.resolve(
+                Schema addPropertiesSchema = this.resolve(
                         new AnnotatedType()
-                                .type(valueType)
-                                .schemaProperty(annotatedType.isSchemaProperty())
-                                .ctxAnnotations(schemaAnnotations)
-                                .skipSchemaName(true)
-                                .resolveAsRef(annotatedType.isResolveAsRef())
-                                .jsonViewAnnotation(annotatedType.getJsonViewAnnotation())
-                                .propertyName(annotatedType.getPropertyName())
-                                .parent(annotatedType.getParent()));
+                        .type(valueType)
+                        .schemaProperty(annotatedType.isSchemaProperty())
+                        .ctxAnnotations(schemaAnnotations) //JLC maybe here
+                        .skipSchemaName(true)
+                        .resolveAsRef(annotatedType.isResolveAsRef())
+                        .jsonViewAnnotation(annotatedType.getJsonViewAnnotation())
+                        .propertyName(annotatedType.getPropertyName())
+                        .parent(annotatedType.getParent()), context,  next );
                 if (addPropertiesSchema != null) {
                     if (StringUtils.isNotBlank(addPropertiesSchema.getName())) {
                         pName = addPropertiesSchema.getName();

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -830,6 +830,7 @@ public class Schema<T> {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("class Schema {\n");
+        sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    format: ").append(toIndentedString(format)).append("\n");
         sb.append("    $ref: ").append(toIndentedString($ref)).append("\n");


### PR DESCRIPTION
Maps do not need context since the key value is unknown at time of generation